### PR TITLE
Fix bug, allowance on card back 3 spots

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,10 @@
 {:paths   ["src"]
  :deps    {org.clojure/clojure {:mvn/version "1.12.0"}}
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps  {io.github.cognitect-labs/test-runner
+                  :extra-deps  {com.clojure-goes-fast/clj-async-profiler
+                                {:mvn/version "1.6.0"}
+                                io.github.cognitect-labs/test-runner
                                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                  :jvm-opts    ["-Djdk.attach.allowAttachSelf"]
                   :main-opts   ["-m" "cognitect.test-runner"]
                   :exec-fn     cognitect.test-runner.api/test}}}

--- a/src/jmshelby/monopoly/cards.clj
+++ b/src/jmshelby/monopoly/cards.clj
@@ -212,8 +212,10 @@
     :as   game-state}
    player card]
   (let [move           (-> game-state :functions :move-to-cell)
-        old-cell       (:cell-residency player)
         [style target] (:card.move/cell card)
+        ;; Determine if allowance should be paid, any move except back
+        allowance?     (not= :back style)
+        old-cell       (:cell-residency player)
         new-cell
         (case style
           :back             (util/next-cell board (* -1 target) old-cell)
@@ -222,7 +224,8 @@
           ;; TODO - Cheating a bit for now ...
           ;;        Make this smarter so it looks better
           [:type :property] (get-next-property-type board old-cell (second target)))]
-    (move game-state new-cell :card)))
+    ;; Make the move
+    (move game-state new-cell :card :allowance? allowance?)))
 
 ;; =====================================================
 

--- a/src/jmshelby/monopoly/core.clj
+++ b/src/jmshelby/monopoly/core.clj
@@ -103,18 +103,32 @@
     :as   game-state}
    new-cell driver]
   (let [;; Get current player info
-        player         (util/current-player game-state)
-        player-id      (:id player)
-        pidx           (:player-index player)
-        player-cash    (:cash player)
-        old-cell       (:cell-residency player)
+        player      (util/current-player game-state)
+        player-id   (:id player)
+        pidx        (:player-index player)
+        player-cash (:cash player)
+        old-cell    (:cell-residency player)
         ;; Check for allowance
         ;; If the old cell index is GT the new,
         ;; then we've looped around, easy
         ;; TODO - this assumes GO is on cell 0, possibly okay...
-        allowance      (get-in board [:cells 0 :allowance])
+        allowance   (get-in board [:cells 0 :allowance])
         ;; TODO - There's a bug where this is incorrect if a
         ;;        card has the person going back 3 spots.
+        ;; Example:
+        ;; {:type :roll, :player "D", :roll [3 3]}
+        ;; {:type :move, :driver :dice, :player "D", :before-cell 16, :after-cell 22}
+        ;; {:type   :card-draw,
+        ;;  :player "D",
+        ;;  :card
+        ;;  {:text           "Go Back 3 Spaces",
+        ;;   :deck           :chance,
+        ;;   :card/effect    :move,
+        ;;   :card.move/cell [:back 3]}}
+        ;; {:type :move, :driver :card, :player "D", :before-cell 22, :after-cell 19}
+        ;; {:type :payment, :from :bank, :to "D", :amount 200, :reason :allowance}
+        ;; {:type :payment, :from "D", :to "A", :amount 16, :reason :rent}
+
         with-allowance (when (> old-cell new-cell)
                          (+ player-cash allowance))
         ;; Initial state update, things that have

--- a/src/jmshelby/monopoly/core.clj
+++ b/src/jmshelby/monopoly/core.clj
@@ -276,14 +276,12 @@
       ;; and move on to next player
       (or (= :bankrupt status) ;; probably don't need to check this?
           (> 0 cash))
-      (do
-        (println "Need to bankrupt player:" player-id)
-        (-> game-state
-            ;; Move to next player FIRST
-            ;; (we can get caught in a loop if we don't do this right)
-            util/apply-end-turn
-            ;; Then process bankruptcy workflow
-            (simple-bankupt-player player-id)))
+      (-> game-state
+          ;; Move to next player FIRST
+          ;; (we can get caught in a loop if we don't do this right)
+          util/apply-end-turn
+          ;; Then process bankruptcy workflow
+          (simple-bankupt-player player-id))
 
       ;; If they have cash, and it's not time to end the train
       ;; proceed with regular player turn
@@ -402,17 +400,18 @@
 
 (defn rand-game-end-state
   "Return a new, random, completed game state, with # of given players"
-  [players]
-  (->> (init-game-state players)
-       (iterate advance-board)
-       ;; Skip past all iterations until game is done, and there is a winner
-       ;; OR, failsafe, the transactions have gone beyond X, most likely endless game
-       (drop-while
-         (fn [{:keys [status transactions]}]
-           (and (= :playing status)
-                ;; Some arbitrary limit
-                (> 1100 (count transactions)))))
-       first))
+  ([players] (rand-game-end-state players 2000))
+  ([players failsafe-thresh]
+   (->> (init-game-state players)
+        (iterate advance-board)
+        ;; Skip past all iterations until game is done, and there is a winner
+        ;; OR, failsafe, the transactions have gone beyond X, most likely endless game
+        (drop-while
+          (fn [{:keys [status transactions]}]
+            (and (= :playing status)
+                 ;; Some arbitrary limit
+                 (> failsafe-thresh (count transactions)))))
+        first)))
 
 (comment
 

--- a/src/jmshelby/monopoly/util.clj
+++ b/src/jmshelby/monopoly/util.clj
@@ -30,8 +30,7 @@
 
 ;; ======= Definition Derivations ==============
 
-;; TODO - could easily memoize this
-(defn street-group-counts
+(defn *street-group-counts
   "Given a board definition, return a map of
   'street' property groups -> count.
   Useful for determining how many of each
@@ -44,6 +43,9 @@
        (group-by :group-name)
        (map (fn [[k coll]] [k (count coll)]))
        (into {})))
+
+(def street-group-counts
+  (memoize *street-group-counts))
 
 (defn jail-cell-index
   "Given a board definition, return the ordinal
@@ -296,7 +298,8 @@
        (map key) set))
 
 ;; TODO - Is a better name owned-properties-details?
-(defn owned-property-details
+;; TODO - this seems to be the most called, and most time spent of the functions ...
+(defn- *owned-property-details
   "Given a game-state, return the set of owned property
   details as a map of prop ID -> owned state with attached:
     - owner ID
@@ -313,6 +316,7 @@
                                [prop-name
                                 (assoc owner-state
                                        :owner (:id player)
+                                       ;; TODO - Performance: cache key by property names for this
                                        :def (->> board :properties
                                                  (filter #(= prop-name (:name %)))
                                                  first))])
@@ -339,6 +343,10 @@
                              ;; TODO - this assumes that only one type of prop has a group name
                              (street-group->count (-> deets :def :group-name))))])))
          (into {}))))
+
+(def owned-property-details
+  ;; *owned-property-details
+  (memoize *owned-property-details))
 
 (defn apply-property-option
   "Given a game state, check if current player is able to buy the property

--- a/test/jmshelby/monopoly/cards_test.clj
+++ b/test/jmshelby/monopoly/cards_test.clj
@@ -1,0 +1,61 @@
+(ns jmshelby.monopoly.cards-test
+  (:require [clojure.test :refer :all]
+            [jmshelby.monopoly.core :as core]
+            [jmshelby.monopoly.cards :as cards]))
+
+;; Types:
+;; - pay
+;;   - w/multiplier
+;;     - # players/houses/hotels
+;; - collect
+;;   - w/multiplier, # players
+;; - retain (get out of jail free)
+;; - incarcerate (jail)
+;; - move
+;;   - "go"
+;;   - specific property
+;;   - next util
+;;   - next railroad
+
+(deftest draw-move-back
+  (let [;; Setup game
+        before (-> (core/init-game-state 4)
+                   ;; with current player landing on community chest
+                   (update-in [:current-turn :dice-rolls] conj [3 4])
+                   (assoc-in [:players 0 :cell-residency] 7)
+                   ;; A certain amount of money
+                   (assoc-in [:players 0 :cash] 1500)
+                   ;; and just a "move back" card available
+                   (assoc-in [:card-queue :chance]
+                             [{:text           "Go Back 3 Spaces",
+                               :deck           :chance,
+                               :card/effect    :move,
+                               :card.move/cell [:back 3]}]))]
+    (let [after (cards/apply-card-draw before)]
+      ;; Moved back 3 and looped around
+      (is (= 4 (get-in after [:players 0 :cell-residency]))
+          "Player moved back 3")
+      ;; Has a certain amount of cash after
+      ;; buying landing on tax AND
+      ;; did _not_ collect allowance
+      (is (= 1300 (get-in after [:players 0 :cash]))
+          "Paid $200, cash balance"))))
+
+(comment
+
+
+  ;; Setup game
+  (-> (core/init-game-state 4)
+      ;; with current player landing on chance
+      (update-in [:current-turn :dice-rolls] conj [3 4])
+      (assoc-in [:players 0 :cell-residency] 7)
+      ;; and just a move back card available
+      (assoc-in [:card-queue :chance]
+                [{:text           "Go Back 3 Spaces",
+                  :deck           :chance
+                  :card/effect    :move,
+                  :card.move/cell [:back 3]}])
+      (cards/apply-card-draw)
+      )
+
+  )

--- a/test/jmshelby/monopoly/cards_test.clj
+++ b/test/jmshelby/monopoly/cards_test.clj
@@ -41,7 +41,7 @@
       ;; after buying landing on tax AND did
       ;; _not_ collect allowance
       (is (= 1300 (get-in after [:players 0 :cash]))
-          "Paid $200, cash balance"))))
+          "Paid $200 tax, cash balance"))))
 
 (comment
 

--- a/test/jmshelby/monopoly/cards_test.clj
+++ b/test/jmshelby/monopoly/cards_test.clj
@@ -17,27 +17,29 @@
 ;;   - next util
 ;;   - next railroad
 
-(deftest draw-move-back
-  (let [;; Setup game
-        before (-> (core/init-game-state 4)
-                   ;; with current player landing on community chest
-                   (update-in [:current-turn :dice-rolls] conj [3 4])
-                   (assoc-in [:players 0 :cell-residency] 7)
-                   ;; A certain amount of money
-                   (assoc-in [:players 0 :cash] 1500)
-                   ;; and just a "move back" card available
-                   (assoc-in [:card-queue :chance]
-                             [{:text           "Go Back 3 Spaces",
-                               :deck           :chance,
-                               :card/effect    :move,
-                               :card.move/cell [:back 3]}]))]
-    (let [after (cards/apply-card-draw before)]
-      ;; Moved back 3 and looped around
+(deftest draw
+  (testing "a 'Move Back' type card"
+    (let [;; Setup game
+          before (-> (core/init-game-state 4)
+                     ;; with current player landing on community chest
+                     (update-in [:current-turn :dice-rolls] conj [3 4])
+                     (assoc-in [:players 0 :cell-residency] 7)
+                     ;; A certain amount of money
+                     (assoc-in [:players 0 :cash] 1500)
+                     ;; and just a "move back" card available
+                     (assoc-in [:card-queue :chance]
+                               [{:text           "Go Back 3 Spaces",
+                                 :deck           :chance,
+                                 :card/effect    :move,
+                                 :card.move/cell [:back 3]}]))
+          ;; Run function in test
+          after  (cards/apply-card-draw before)]
+      ;; Assert, moved back 3 and looped around
       (is (= 4 (get-in after [:players 0 :cell-residency]))
           "Player moved back 3")
-      ;; Has a certain amount of cash after
-      ;; buying landing on tax AND
-      ;; did _not_ collect allowance
+      ;; Assert, has a certain amount of cash
+      ;; after buying landing on tax AND did
+      ;; _not_ collect allowance
       (is (= 1300 (get-in after [:players 0 :cash]))
           "Paid $200, cash balance"))))
 

--- a/test/jmshelby/monopoly/core_test.clj
+++ b/test/jmshelby/monopoly/core_test.clj
@@ -6,6 +6,6 @@
 (deftest exercise-game
   ;; TODO - this can be parallelized easily
   (doseq [n (range 40)]
-    (println "Running sim " n)
-    (let [end-state (c/rand-game-end-state 4)]
+    (print "Running sim " n)
+    (let [end-state (c/rand-game-end-state 4 1000)]
       (println "  -> Status: " (:status end-state) " (" (-> end-state :transactions count) ")"))))


### PR DESCRIPTION
There is a bug, which happens when you draw the card that moves you back 3 spaces, which automatically gives you a "GO" allowance, regardless of where you are on the board.