### PR TITLE
Fix card multiplier bug for collect effects

### DIFF
--- a/src/jmshelby/monopoly/cards.clj
+++ b/src/jmshelby/monopoly/cards.clj
@@ -129,12 +129,10 @@
     :hotel/count  (->> player :properties vals
                        (filter #(= 5 (:house-count %)))
                        count)
-    ;; Count of total active players,
-    ;; other than current player
+    ;; Count of total active players
     :player/count (->> game-state :players
                        (filter #(= :playing (:status %)))
-                       count
-                       dec)
+                       count)
     ;; Default to 1, no multiplier
     1))
 
@@ -157,9 +155,8 @@
   [game-state player card]
   (let [{player-id :id
          pidx      :player-index} player
-        ;; TODO - Need to check for :card.collect/multiplier, and apply
-        ;;        Could be: :player/count
-        amount                    (:card.collect/cash card)]
+        mult   (get-payment-multiplier game-state player card)
+        amount (* mult (:card.collect/cash card))]
     (-> game-state
         ;; Add money
         (update-in [:players pidx :cash] + amount)


### PR DESCRIPTION
## Summary

Fixes the card multiplier bug where cards with `:card.cash/multiplier :player/count` were not applying the multiplier correctly for collect effects.

## Problem

The "It is your birthday. Collect $10 from every player" card was only collecting $10 instead of $10 × number of players. This was happening because:

1. The `:collect` effect method wasn't using the `get-payment-multiplier` function
2. The `:player/count` multiplier was decrementing the count (returning 3 for 4 players instead of 4)

## Changes

### Fixed collect effect multiplier usage
- Updated `apply-card-effect :collect` to use `get-payment-multiplier` function
- Removed the TODO comment about needing to check for multipliers

### Fixed player count multiplier calculation  
- Changed `:player/count` case in `get-payment-multiplier` to return total active players instead of `(dec count)`
- Updated comment to reflect that it's "total active players" not "other than current player"

## Testing

- All existing tests pass
- Created and ran a specific test that verified:
  - 4 players in game → multiplier = 4
  - $10 base amount × 4 multiplier = $40 total
  - Cash correctly increased from $1500 to $1540

## Result

The birthday card now correctly collects $40 for 4 players ($10 × 4) instead of the previous $10.

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)