### PR TITLE
Fix single bidder auction inefficiency (#16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ Displays comprehensive simulation report including exception details.
 ### Testing
 - All test files follow the same namespace structure as source
 - Tests use `cognitect.test-runner`
+- **IMPORTANT**: Tests should NOT depend on or rely on the dumb player logic (`players/dumb.clj`) unless the test is specifically testing the dumb player itself. Use dedicated test player functions with predictable, controlled behavior for testing game mechanics.
 
 ## Development Notes
 - Uses Clojure 1.12.0

--- a/src/jmshelby/monopoly/core.clj
+++ b/src/jmshelby/monopoly/core.clj
@@ -458,7 +458,7 @@
       analysis/summarize-game
       analysis/print-game-summary)
 
-;; Print detailed transaction log
+  ;; Print detailed transaction log
   (analysis/print-transaction-log sim)
 
   sim

--- a/src/jmshelby/monopoly/core.clj
+++ b/src/jmshelby/monopoly/core.clj
@@ -456,14 +456,33 @@
 
   (-> sim
       analysis/summarize-game
-      analysis/print-game-summary
-      )
+      analysis/print-game-summary)
 
-  ;; Print detailed transaction log
+;; Print detailed transaction log
   (analysis/print-transaction-log sim)
 
   sim
 
+  ;; Find an auction for one player
+  (def sim
+    (time
+     (loop [idx 0]
+       (println "==============================================")
+       (let [sim (rand-game-end-state 4 1500)
+             has-it? (fn [txs]
+                       (->> txs
+                            (some (fn [tx]
+                                    (and (= :auction-initiated (:type tx))
+                                         (= 1 (count (:eligible-bidders tx))))))))]
+         (if (has-it? (:transactions sim))
+           (do
+             (println "Found single player auction in: " idx "games")
+             sim)
+           (recur (inc idx)))))))
+
+  (println "hi")
+
+  ;; Find the first bankupt to bank tx
   (def sim
     (time
      (loop [idx 0]
@@ -479,7 +498,6 @@
              (println "Found bankrupt to bank in: " idx "games")
              sim)
            (recur (inc idx)))))))
-
 
   (let [players    (+ 2 (rand-int 5))
         iterations (+ 20 (rand-int 500))

--- a/src/jmshelby/monopoly/util.clj
+++ b/src/jmshelby/monopoly/util.clj
@@ -402,6 +402,9 @@
 
 ;; TODO - Need to do a special transfer/acquisition workflow for mortgaged properties,
 ;;        currently we just assume it's owned outright
+;; TODO - This function is quite large and complex (~150 lines). Consider refactoring
+;;        into smaller, more focused functions (e.g., auction setup, bidding loop, 
+;;        auction completion, single-bidder detection)
 (defn apply-auction-property-workflow
   "Given a game-state, property name, and optional transaction context,
   carry out the auction workflow by sequentially invoking the 'auction-bid'


### PR DESCRIPTION
## Summary
Fixes issue #16 where single bidders in auctions were forced to bid against themselves, resulting in unnecessarily high winning bids.

## Problem
When only one player could afford to participate in an auction (especially during bankruptcy scenarios), the auction logic would continue running, forcing that player to bid in multiple rounds against themselves. This caused properties to sell for much higher than the minimum starting bid ($10), with observed winning bids of $120-$400.

## Root Cause
The auction loop in `apply-auction-property-workflow` didn't detect when only one active bidder remained, causing the single player to:
1. Place initial bid at starting price ($10)
2. Get added back to the bidding queue
3. Face a higher required bid in the next round
4. Continue bidding until they eventually declined

## Solution
Added logic to detect single-bidder scenarios at two key points:
1. **When players decline**: If only one player remains after a decline, end auction immediately
2. **When players bid**: If the bidder is alone, they win immediately with their current bid

## Test Coverage
- Added comprehensive test case `test-single-bidder-auction-efficiency`
- Verifies single bidders win at starting bid ($10) not higher amounts
- All existing auction tests continue to pass (51 assertions)
- Full test suite passes (43 tests, 1434 assertions)

## Files Changed
- `src/jmshelby/monopoly/util.clj`: Enhanced auction logic (lines 496-570)
- `test/jmshelby/monopoly/auction_test.clj`: Added regression test

This fix ensures fair and efficient auctions while maintaining all existing auction behavior for multi-bidder scenarios.