### PR TITLE
Fix: End turn after escaping jail with doubles

### DIFF
--- a/src/jmshelby/monopoly/util.cljc
+++ b/src/jmshelby/monopoly/util.cljc
@@ -259,10 +259,9 @@
               (append-tx {:type   :bail
                           :player player-id
                           :means  [:roll :double new-roll]})
-              ;; TODO - Somehow need to signal that they don't get another
-              ;;        roll, because a double thrown while in jail doesn't
-              ;;        grant that priviledge
-              (apply-dice-roll new-roll))
+              (apply-dice-roll new-roll)
+              ;; End turn - doubles from jail don't grant extra roll
+              apply-end-turn)
 
           ;; Not a double, third attempt.
           ;; Force bail payment, and move


### PR DESCRIPTION
## Summary
- Fixed bug where rolling doubles to escape jail incorrectly granted an extra roll
- Added `apply-end-turn` after jail escape via doubles to comply with Monopoly rules

## Changes
- Modified `src/jmshelby/monopoly/util.cljc:264` to end turn after escaping jail with doubles

Fixes #22

Generated with [Claude Code](https://claude.ai/code)