### PR TITLE
Temporarily disable Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   claude-review:
+    # Temporarily disabled
+    if: false
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Summary
- Adds `if: false` condition to the claude-review job to disable it
- Keeps the workflow file intact for easy re-enablement later
- Workflow will be skipped on all PRs until re-enabled

## Re-enabling
To re-enable the workflow, simply remove or comment out the `if: false` line.