### PR TITLE
Remove stale TODO comment from can-sell-house?

### DIFF
--- a/src/jmshelby/monopoly/util.cljc
+++ b/src/jmshelby/monopoly/util.cljc
@@ -914,7 +914,6 @@
 
 (defn can-sell-house?
   [game-state player prop-name]
-  ;; TODO - the player in question should probably be passed as a prop
   (let [{player-id :id} player
         ;; All properties owned
         owned       (->> game-state


### PR DESCRIPTION
Removes the outdated TODO comment from `can-sell-house?` in `util.cljc`. The `player` parameter was already added to the function signature, so the comment was misleading.

Closes #8

Generated with [Claude Code](https://claude.ai/code)